### PR TITLE
Remove “Subject” from SigningKey if content of Subject is None

### DIFF
--- a/src/validatesns/__init__.py
+++ b/src/validatesns/__init__.py
@@ -182,7 +182,7 @@ class SignatureValidator(object):
         message_type = message.get("Type")
 
         if message_type == "Notification":
-            if "Subject" in message:
+            if "Subject" in message and message["Subject"] is not None:
                 return ("Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type")
             else:
                 return ("Message", "MessageId", "Timestamp", "TopicArn", "Type",)


### PR DESCRIPTION
SNS may send a notification with key `Subject` and value is `null` (in Python `None`).
This will exclude `Subject` if value is `None`.

Thanks for checking.


Event example:
```
{
    "Records": [
        {
            "EventSource": "aws:sns",
            "EventVersion": "1.0",
            "EventSubscriptionArn": "arn:aws:sns:ap-northeast-1:123456789012:SOME_SNS_TOPIC_NAME:156e4227-90b0-4b1c-80ac-7b1f6c747013",
            "Sns": {
                "Type": "Notification",
                "MessageId": "d7fd7885-190a-5ac1-9026-2da51a5f1bda",
                "TopicArn": "arn:aws:sns:ap-northeast-1:123456789012:SOME_SNS_TOPIC_NAME",
                "Subject": null,
                "Message": "{\"id\": [1766]}",
                "Timestamp": "2019-04-04T13:05:25.819Z",
                "SignatureVersion": "1",
                "Signature": "___SIGNATURE___",
                "SigningCertUrl": "https://sns.ap-northeast-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
                "UnsubscribeUrl": "https://sns.ap-northeast-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ap-northeast-1:123456789012:SOME_SNS_TOPIC_NAME:156e4227-90b0-4b1c-80ac-7b1f6c747013",
                "MessageAttributes": {}
            }
        }
    ]
}
```